### PR TITLE
Implement `enforce_plaintext` config flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,6 @@ jobs:
       matrix:
         name:
           - linux / stable
-          - linux / beta
           # - linux / nightly
           - macOS / stable
           - windows / stable-x86_64-msvc
@@ -86,9 +85,6 @@ jobs:
 
         include:
           - name: linux / stable
-            test-features: "--features __internal_proxy_sys_no_cache"
-          - name: linux / beta
-            rust: beta
             test-features: "--features __internal_proxy_sys_no_cache"
           # - name: linux / nightly
           #   rust: nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cf-reqwest"
-version = "0.11.20" # remember to update html_root_url
+version = "0.12.0" # remember to update html_root_url
 description = "higher level HTTP client library"
 keywords = ["http", "request", "client"]
 categories = ["web-programming::http-client", "wasm"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 #![deny(missing_debug_implementations)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(test, deny(warnings))]
-#![doc(html_root_url = "https://docs.rs/reqwest/0.11.20")]
+#![doc(html_root_url = "https://docs.rs/cf-reqwest/0.12.0")]
 
 //! # reqwest
 //!

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -1670,6 +1670,7 @@ mod test {
             false
         }
 
+        #[track_caller]
         fn check_parse_error(url: &str, needle: url::ParseError) {
             let error = Proxy::http(url).unwrap_err();
             if !includes(&error, needle) {
@@ -1863,7 +1864,7 @@ mod test {
 
                 #[test]
                 fn invalid_domain_character() {
-                    check_parse_error("http://abc 123/", url::ParseError::IdnaError);
+                    check_parse_error("http://abc 123/", url::ParseError::InvalidDomainCharacter);
                 }
             }
         }

--- a/tests/client.rs
+++ b/tests/client.rs
@@ -85,6 +85,39 @@ async fn user_agent() {
 }
 
 #[tokio::test]
+async fn enforce_plaintext() {
+    let server = server::http(move |_req| async { http::Response::new("Hello".into()) });
+
+    let url = format!("http://{}/text", server.addr());
+
+    let res = cf_reqwest::Client::builder()
+        .enforce_plaintext(true)
+        .build()
+        .expect("client builder")
+        .get(&url)
+        .send()
+        .await
+        .expect("request");
+
+    let text = res.text().await.expect("Failed to get text");
+    assert_eq!("Hello", text);
+
+    let url = format!("https://{}/text", server.addr());
+
+    let res = cf_reqwest::Client::builder()
+        .enforce_plaintext(true)
+        .build()
+        .expect("client builder")
+        .get(&url)
+        .send()
+        .await
+        .expect("request");
+
+    let text = res.text().await.expect("Failed to get text");
+    assert_eq!("Hello", text);
+}
+
+#[tokio::test]
 async fn response_text() {
     let _ = env_logger::try_init();
 


### PR DESCRIPTION
The flag enforces reqwest to send plaintext even for HTTPS URLs. This is useful when request goes through a machine-local proxy chain with a latest hop in this chain doing actual encryption before egressing to the Internet.